### PR TITLE
allow writeTemplate to return a new object, updgrade deps, fix docs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,8 @@ env: TARGET=test
 
 node_js:
   - 'node'
+  - '8'
+  - '7'
   - '6'
   - '5'
   - '4'

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 bunyan-stream-elasticsearch
 ===========================
 
-[![npm version](https://badge.fury.io/js/bloublou2014/bunyan-stream-elasticsearch.svg)](http://badge.fury.io/js/bunyan-stream-elasticsearch)
+[![npm version](https://badge.fury.io/js/bunyan-stream-elasticsearch.svg)](https://badge.fury.io/js/bunyan-stream-elasticsearch)
 [![Build Status](https://travis-ci.org/bloublou2014/bunyan-stream-elasticsearch.svg)](https://travis-ci.org/bloublou2014/bunyan-stream-elasticsearch)
 [![Dependency Status](https://david-dm.org/bloublou2014/bunyan-stream-elasticsearch.svg)](https://david-dm.org/bloublou2014/bunyan-stream-elasticsearch)
-[![Dev Dependency Status](https://david-dm.org/bloublou2014/bunyan-stream-elasticsearch/dev-status.svg)](https://david-dm.org/bloublou2014/bunyan-stream-elasticsearch#info=devDependencies)
+[![Dev Dependency Status](https://david-dm.org/bloublou2014/bunyan-stream-elasticsearch/dev-status.svg)](https://david-dm.org/bloublou2014/bunyan-stream-elasticsearch#type=dev)
 [![Known Vulnerabilities](https://snyk.io/test/github/bloublou2014/bunyan-stream-elasticsearch/badge.svg)](https://snyk.io/test/github/bloublou2014/bunyan-stream-elasticsearch)
 
 A Bunyan stream for saving logs into Elasticsearch 5.x with custom write function.
@@ -17,41 +17,40 @@ npm install bunyan-stream-elasticsearch
 
 ## Logstash Template
 
-By default bunyan-stream-elasticsearch will create an index with a specific mapping template for your indexPattern. Template name will be 'template-logstash-' with default settings.
-If your index pattern is for example '[test-]YYYY.MM.DD[-pattern]', template name will be 'template-test--pattern'. Each time node app is starting, template is overwrite.
-You can disabled it via option `template:false` or overwrite it via `template:{es template}`.
+By default bunyan-stream-elasticsearch will create an index with a specific mapping template for your `indexPattern`. Template name will be `template-logstash-` with default settings.
+If your index pattern is for example `[test-]YYYY.MM.DD[-pattern]` the template name will be `template-test--pattern`. Each time an instance of this stream is created, the template will be overwritten.
+You can disable it by passing the option `template: false` or provide your own via `template: {elastic template}`.
 
-## Custom Write function
+## Custom Write Function
 
 You can add or modify elasticsearch document providing a `write(entry)` callback option.
-This allow a fine tuning on how document will be defined. Do not forget to override default template if you add new fields.
+This allows a fine tuning on how the document will be defined. Do not forget to override the default template if you add new fields.
 
 ## Example
 
-```
-let bunyan = require('bunyan');
-let bunyanStreamElasticsearch = require('bunyan-elasticsearch');
+```js
+const bunyan = require('bunyan');
+const ElasticsearchStream = require('bunyan-stream-elasticsearch');
 
-let writeEntryCallback = function(entry) {
+const writeCallback = entry => {
    // modify entry values
    entry.myProperty = 'my value';
+   return entry;
 };
 
-let esStream = new bunyanStreamElasticsearch({
+const esStream = new ElasticsearchStream({
   indexPattern: '[logstash-]YYYY.MM.DD',
   type: 'logs',
   host: 'localhost:9200',
-  defaultTemplate:true,
-  writeCallback : writeEntryCallback
+  defaultTemplate: true,
+  writeCallback,
 });
 
 // manage error case
-esStream.on('error', function (err) {
-  console.log('Buyan Stream Elasticsearch Error:', err.stack);
-});
+esStream.on('error', err => console.log('Buyan Stream Elasticsearch Error:', err.stack));
 
 // Create the logger itself
-let logger = bunyan.createLogger({
+const logger = bunyan.createLogger({
   name: "My Application",
   streams: [
     // default stream to console
@@ -72,7 +71,7 @@ logger.info('Starting application on port %d', app.get('port'));
 * `type` {string|function}: Elasticsearch `type` field. Default: `'logs'`
 * `indexPattern` {string}: Used to generate index if `index` option not set. Default: `'[logstash-]YYYY.MM.DD'`
 * `index` {string|function}: Elasticsearch index. Defaults to index generated using index pattern
-* `template` {json|boolean}: Elasticsearch Template to push to elasticseach at each start. if `false` no template will be pushed, if `{...}` will act as template remplacement.
-* `writeCallback` {function} : Custom write callback to modify entry before pushing it to Elasticsearch. 
+* `template` {object|boolean}: Elasticsearch Template to push to elasticseach at each start. If `false` no template will be pushed, if `{...}` will act as template replacement.
+* `writeCallback` {function} : Custom write callback to modify the log entry before pushing it to Elasticsearch. 
 
 Options `type` and `index` can be either a string or function. For these options, when the option is set to a function, the function is passed the log entry object as an argument

--- a/index.js
+++ b/index.js
@@ -56,7 +56,7 @@ class ElasticsearchStream extends Writable {
     let indexPattern = options.indexPattern || '[logstash-]YYYY.MM.DD';
     this._index = options.index || generateIndexName.bind(null, indexPattern);
     this._writeCallback = options.writeCallback;
-    this._template = options.template || defaultTemplate;
+    this._template = options.template == null || options.template === true ? defaultTemplate : options.template;
 
     // async
     this.initTemplate(options.index || indexPattern, this._template);

--- a/index.js
+++ b/index.js
@@ -1,11 +1,12 @@
+'use strict';
+
 const Writable = require('stream').Writable;
-const util = require('util');
 const elasticsearch = require('elasticsearch');
 const moment = require('moment');
 const defaultTemplate = require('./template.json');
 const _ = require('lodash');
 
-let levels = {
+const levels = {
   10: 'trace',
   20: 'debug',
   30: 'info',
@@ -19,7 +20,7 @@ function generateIndexName(pattern, entry) {
 }
 
 function callOrString(value, entry) {
-  if (typeof(value) === 'function') {
+  if (typeof (value) === 'function') {
     return value(entry);
   }
   return value;
@@ -46,89 +47,84 @@ function generateRawTemplateName(pattern) {
   };
 }
 
+class ElasticsearchStream extends Writable {
+  constructor(options) {
+    super(options);
+    options = options || {};
+    this._client = options.client || new elasticsearch.Client(options);
+    this._type = options.type || 'logs';
+    let indexPattern = options.indexPattern || '[logstash-]YYYY.MM.DD';
+    this._index = options.index || generateIndexName.bind(null, indexPattern);
+    this._writeCallback = options.writeCallback;
+    this._template = options.template || defaultTemplate;
 
-function ElasticsearchStream(options) {
-  options = options || {};
-  this._client = options.client || new elasticsearch.Client(options);
-  this._type = options.type || 'logs';
-  let indexPattern = options.indexPattern || '[logstash-]YYYY.MM.DD';
-  this._index = options.index || generateIndexName.bind(null, indexPattern);
-  this._writeCallback = options.writeCallback || undefined;
-  this._template = options.template || defaultTemplate;
-
-  // async
-  this.initTemplate(options.index || indexPattern, this._template);
-
-  Writable.call(this, options);
-}
-
-util.inherits(ElasticsearchStream, Writable);
-
-
-ElasticsearchStream.prototype.initTemplate = function (name, template) {
-  if (template === false)
-    return;
-
-  let tpl = generateRawTemplateName(name);
-
-  template.template = tpl.template;
-
-  return this._client.indices.putTemplate({
-    name: tpl.name,
-    create: false, // can be replace a previous one
-    body: template
-  });
-};
-
-ElasticsearchStream.prototype._write = function (entry, encoding, callback) {
-
-  let client = this._client;
-  let index = this._index;
-  let type = this._type;
-
-  let input = JSON.parse(entry.toString('utf8'));
-
-  // Reassign these fields so them match what the default Kibana dashboard
-  // expects to see.
-  let output = {
-    // The _timestamp field is deprecated. Instead, use a normal date field and set its value explicitly.
-    'date': input.time,
-    'level_int': input.level,
-    'level': levels[input.level],
-    'message': input.msg,
-    'datestamp': moment(input.time).format('YYYY.MM.DD'),
-  };
-
-  // merge
-  output = _.defaults(output, input);
-
-  delete output.msg;
-  delete output.v;
-  delete output.time;
-
-
-  if (input.err) {
-    output.error = input.err;
-    if (!output.message) output.message = output.error.message;
+    // async
+    this.initTemplate(options.index || indexPattern, this._template);
   }
 
-  if (this._writeCallback) {
-    this._writeCallback(output, input);
+  initTemplate(name, template) {
+    if (template === false)
+      return;
+
+    let tpl = generateRawTemplateName(name);
+
+    template.template = tpl.template;
+
+    return this._client.indices.putTemplate({
+      name: tpl.name,
+      create: false, // can replace a previous one
+      body: template
+    });
   }
 
-  let options = {
-    index: callOrString(index, entry),
-    type: callOrString(type, entry),
-    body: output
-  };
+  _write(entry, encoding, callback) {
+    const client = this._client;
+    const index = this._index;
+    const type = this._type;
 
-  let self = this;
-  client.index(options, function (err) {
-    if (err) {
-      self.emit('error', err);
+    const input = JSON.parse(entry.toString('utf8'));
+
+    // Reassign these fields so them match what the default Kibana dashboard
+    // expects to see.
+    let output = {
+      // The _timestamp field is deprecated. Instead, use a normal date field and set its value explicitly.
+      'date': input.time,
+      'level_int': input.level,
+      'level': levels[input.level],
+      'message': input.msg,
+      'datestamp': moment(input.time).format('YYYY.MM.DD'),
+    };
+
+    // merge
+    output = _.defaults(output, input);
+
+    delete output.msg;
+    delete output.v;
+    delete output.time;
+
+    if (input.err) {
+      output.error = input.err;
+      if (!output.message) output.message = output.error.message;
     }
-    callback();
-  });
-};
+
+    if (this._writeCallback) {
+      output = this._writeCallback(output, input) || output;
+    }
+
+    const options = {
+      index: callOrString(index, entry),
+      type: callOrString(type, entry),
+      body: output
+    };
+
+    const self = this;
+    client.index(options, function (err) {
+      if (err) {
+        self.emit('error', err);
+      }
+      callback();
+    });
+  }
+}
 
 module.exports = ElasticsearchStream;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,449 @@
+{
+  "name": "bunyan-stream-elasticsearch",
+  "version": "0.6.1",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "agentkeepalive": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/agentkeepalive/-/agentkeepalive-2.2.0.tgz",
+      "integrity": "sha1-xdG9SxKQCPEWPyNvhuX66iAm4u8="
+    },
+    "ansi-regex": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
+    },
+    "ansi-styles": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+      "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
+    },
+    "balanced-match": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+      "dev": true
+    },
+    "bluebird": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.0.tgz",
+      "integrity": "sha1-eRQg1/VR7qKJdFOop3ZT+WYG1nw=",
+      "dev": true
+    },
+    "brace-expansion": {
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
+      "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
+      "dev": true,
+      "requires": {
+        "balanced-match": "1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "browser-stdout": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.0.tgz",
+      "integrity": "sha1-81HTKWnTL6XXpVZxVCY9korjvR8=",
+      "dev": true
+    },
+    "chalk": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+      "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+      "requires": {
+        "ansi-styles": "2.2.1",
+        "escape-string-regexp": "1.0.5",
+        "has-ansi": "2.0.0",
+        "strip-ansi": "3.0.1",
+        "supports-color": "2.0.0"
+      }
+    },
+    "commander": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
+      "integrity": "sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=",
+      "dev": true,
+      "requires": {
+        "graceful-readlink": "1.0.1"
+      }
+    },
+    "concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+      "dev": true
+    },
+    "debug": {
+      "version": "2.6.8",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
+      "integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw=",
+      "dev": true,
+      "requires": {
+        "ms": "2.0.0"
+      }
+    },
+    "diff": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-3.2.0.tgz",
+      "integrity": "sha1-yc45Okt8vQsFinJck98pkCeGj/k=",
+      "dev": true
+    },
+    "elasticsearch": {
+      "version": "13.3.1",
+      "resolved": "https://registry.npmjs.org/elasticsearch/-/elasticsearch-13.3.1.tgz",
+      "integrity": "sha1-xTCuqa+xfqkcPQpW8fERukm8kjk=",
+      "requires": {
+        "agentkeepalive": "2.2.0",
+        "chalk": "1.1.3",
+        "lodash": "2.4.2",
+        "lodash.get": "4.4.2",
+        "lodash.isempty": "4.4.0",
+        "lodash.trimend": "4.5.1"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "2.4.2",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz",
+          "integrity": "sha1-+t2DS5aDBz2hebPq5tnA0VBT9z4="
+        }
+      }
+    },
+    "escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
+    },
+    "fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+      "dev": true
+    },
+    "glob": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
+      "integrity": "sha1-gFIR3wT6rxxjo2ADBs31reULLsg=",
+      "dev": true,
+      "requires": {
+        "fs.realpath": "1.0.0",
+        "inflight": "1.0.6",
+        "inherits": "2.0.3",
+        "minimatch": "3.0.4",
+        "once": "1.4.0",
+        "path-is-absolute": "1.0.1"
+      }
+    },
+    "graceful-readlink": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
+      "integrity": "sha1-TK+tdrxi8C+gObL5Tpo906ORpyU=",
+      "dev": true
+    },
+    "growl": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/growl/-/growl-1.9.2.tgz",
+      "integrity": "sha1-Dqd0NxXbjY3ixe3hd14bRayFwC8=",
+      "dev": true
+    },
+    "has-ansi": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+      "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+      "requires": {
+        "ansi-regex": "2.1.1"
+      }
+    },
+    "has-flag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
+      "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
+      "dev": true
+    },
+    "he": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/he/-/he-1.1.1.tgz",
+      "integrity": "sha1-k0EP0hsAlzUVH4howvJx80J+I/0=",
+      "dev": true
+    },
+    "inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "dev": true,
+      "requires": {
+        "once": "1.4.0",
+        "wrappy": "1.0.2"
+      }
+    },
+    "inherits": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+      "dev": true
+    },
+    "json3": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/json3/-/json3-3.3.2.tgz",
+      "integrity": "sha1-PAQ0dD35Pi9cQq7nsZvLSDV19OE=",
+      "dev": true
+    },
+    "lodash": {
+      "version": "4.17.4",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+      "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4="
+    },
+    "lodash._baseassign": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/lodash._baseassign/-/lodash._baseassign-3.2.0.tgz",
+      "integrity": "sha1-jDigmVAPIVrQnlnxci/QxSv+Ck4=",
+      "dev": true,
+      "requires": {
+        "lodash._basecopy": "3.0.1",
+        "lodash.keys": "3.1.2"
+      }
+    },
+    "lodash._basecopy": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz",
+      "integrity": "sha1-jaDmqHbPNEwK2KVIghEd08XHyjY=",
+      "dev": true
+    },
+    "lodash._basecreate": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash._basecreate/-/lodash._basecreate-3.0.3.tgz",
+      "integrity": "sha1-G8ZhYU2qf8MRt9A78WgGoCE8+CE=",
+      "dev": true
+    },
+    "lodash._getnative": {
+      "version": "3.9.1",
+      "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
+      "integrity": "sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U=",
+      "dev": true
+    },
+    "lodash._isiterateecall": {
+      "version": "3.0.9",
+      "resolved": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz",
+      "integrity": "sha1-UgOte6Ql+uhCRg5pbbnPPmqsBXw=",
+      "dev": true
+    },
+    "lodash.create": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.create/-/lodash.create-3.1.1.tgz",
+      "integrity": "sha1-1/KEnw29p+BGgruM1yqwIkYd6+c=",
+      "dev": true,
+      "requires": {
+        "lodash._baseassign": "3.2.0",
+        "lodash._basecreate": "3.0.3",
+        "lodash._isiterateecall": "3.0.9"
+      }
+    },
+    "lodash.get": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
+      "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk="
+    },
+    "lodash.isarguments": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
+      "integrity": "sha1-L1c9hcaiQon/AGY7SRwdM4/zRYo=",
+      "dev": true
+    },
+    "lodash.isarray": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
+      "integrity": "sha1-eeTriMNqgSKvhvhEqpvNhRtfu1U=",
+      "dev": true
+    },
+    "lodash.isempty": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/lodash.isempty/-/lodash.isempty-4.4.0.tgz",
+      "integrity": "sha1-b4bL7di+TsmHvpqvM8loTbGzHn4="
+    },
+    "lodash.keys": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
+      "integrity": "sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo=",
+      "dev": true,
+      "requires": {
+        "lodash._getnative": "3.9.1",
+        "lodash.isarguments": "3.1.0",
+        "lodash.isarray": "3.0.4"
+      }
+    },
+    "lodash.trimend": {
+      "version": "4.5.1",
+      "resolved": "https://registry.npmjs.org/lodash.trimend/-/lodash.trimend-4.5.1.tgz",
+      "integrity": "sha1-EoBENyhrmMrYmWt5QU4RMAEUCC8="
+    },
+    "minimatch": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "dev": true,
+      "requires": {
+        "brace-expansion": "1.1.8"
+      }
+    },
+    "minimist": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+      "dev": true
+    },
+    "mkdirp": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+      "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+      "dev": true,
+      "requires": {
+        "minimist": "0.0.8"
+      }
+    },
+    "mocha": {
+      "version": "3.5.3",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-3.5.3.tgz",
+      "integrity": "sha512-/6na001MJWEtYxHOV1WLfsmR4YIynkUEhBwzsb+fk2qmQ3iqsi258l/Q2MWHJMImAcNpZ8DEdYAK72NHoIQ9Eg==",
+      "dev": true,
+      "requires": {
+        "browser-stdout": "1.3.0",
+        "commander": "2.9.0",
+        "debug": "2.6.8",
+        "diff": "3.2.0",
+        "escape-string-regexp": "1.0.5",
+        "glob": "7.1.1",
+        "growl": "1.9.2",
+        "he": "1.1.1",
+        "json3": "3.3.2",
+        "lodash.create": "3.1.1",
+        "mkdirp": "0.5.1",
+        "supports-color": "3.1.2"
+      },
+      "dependencies": {
+        "supports-color": {
+          "version": "3.1.2",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.1.2.tgz",
+          "integrity": "sha1-cqJiiU2dQIuVbKBf83su2KbiotU=",
+          "dev": true,
+          "requires": {
+            "has-flag": "1.0.0"
+          }
+        }
+      }
+    },
+    "moment": {
+      "version": "2.18.1",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.18.1.tgz",
+      "integrity": "sha1-w2GT3Tzhwu7SrbfIAtu8d6gbHA8="
+    },
+    "ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+      "dev": true
+    },
+    "once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "dev": true,
+      "requires": {
+        "wrappy": "1.0.2"
+      }
+    },
+    "path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+      "dev": true
+    },
+    "require-new": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/require-new/-/require-new-1.1.1.tgz",
+      "integrity": "sha1-bjrwWmkPViRgndNMJzyQZYbb8cU=",
+      "dev": true,
+      "requires": {
+        "stack-trace": "0.0.9"
+      }
+    },
+    "should": {
+      "version": "13.0.1",
+      "resolved": "https://registry.npmjs.org/should/-/should-13.0.1.tgz",
+      "integrity": "sha512-PyGb++NcZXyHq1lK4Lv9JC2/qjRia1gsE6wrMEOpJX1t7bxEZlY0oYijSq7xgvp6rPJiH8DVvcmw/LWtFaw1vw==",
+      "dev": true,
+      "requires": {
+        "should-equal": "2.0.0",
+        "should-format": "3.0.3",
+        "should-type": "1.4.0",
+        "should-type-adaptors": "1.0.1",
+        "should-util": "1.0.0"
+      }
+    },
+    "should-equal": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/should-equal/-/should-equal-2.0.0.tgz",
+      "integrity": "sha512-ZP36TMrK9euEuWQYBig9W55WPC7uo37qzAEmbjHz4gfyuXrEUgF8cUvQVO+w+d3OMfPvSRQJ22lSm8MQJ43LTA==",
+      "dev": true,
+      "requires": {
+        "should-type": "1.4.0"
+      }
+    },
+    "should-format": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/should-format/-/should-format-3.0.3.tgz",
+      "integrity": "sha1-m/yPdPo5IFxT04w01xcwPidxJPE=",
+      "dev": true,
+      "requires": {
+        "should-type": "1.4.0",
+        "should-type-adaptors": "1.0.1"
+      }
+    },
+    "should-type": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/should-type/-/should-type-1.4.0.tgz",
+      "integrity": "sha1-B1bYzoRt/QmEOmlHcZ36DUz/XPM=",
+      "dev": true
+    },
+    "should-type-adaptors": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/should-type-adaptors/-/should-type-adaptors-1.0.1.tgz",
+      "integrity": "sha1-7+VVPN9oz/ZuXF9RtxLcNRx3vqo=",
+      "dev": true,
+      "requires": {
+        "should-type": "1.4.0",
+        "should-util": "1.0.0"
+      }
+    },
+    "should-util": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/should-util/-/should-util-1.0.0.tgz",
+      "integrity": "sha1-yYzaN0qmsZDfi6h8mInCtNtiAGM=",
+      "dev": true
+    },
+    "stack-trace": {
+      "version": "0.0.9",
+      "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.9.tgz",
+      "integrity": "sha1-qPbq7KkGdMMz58Q5U/J1tFFRBpU=",
+      "dev": true
+    },
+    "strip-ansi": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+      "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+      "requires": {
+        "ansi-regex": "2.1.1"
+      }
+    },
+    "supports-color": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+      "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
+    },
+    "wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+      "dev": true
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bunyan-stream-elasticsearch",
-  "version": "0.6.1",
+  "version": "0.7.0",
   "description": "A Bunyan stream for sending log data to Elasticsearch with custom entry function",
   "main": "index.js",
   "scripts": {
@@ -11,7 +11,7 @@
     "url": "git://github.com/bloublou2014/bunyan-stream-elasticsearch.git"
   },
   "engines": {
-    "node": ">= 7.0.0"
+    "node": ">= 4.0.0"
   },
   "keywords": [
     "Bunyan",
@@ -26,7 +26,7 @@
   },
   "homepage": "https://github.com/bloublou2014/bunyan-stream-elasticsearch",
   "dependencies": {
-    "elasticsearch": "^12.1.3",
+    "elasticsearch": "^13.3.1",
     "lodash": "^4.17.4",
     "moment": "^2.17.1"
   },
@@ -35,6 +35,6 @@
     "lodash": "^4.17.4",
     "mocha": "^3.2.0",
     "require-new": "^1.1.1",
-    "should": "^11.2.0"
+    "should": "^13.0.1"
   }
 }

--- a/tests/connection.js
+++ b/tests/connection.js
@@ -1,4 +1,4 @@
-'use-strict';
+'use strict';
 
 let should = require('should'),
   helper = require('./helper');

--- a/tests/helper.js
+++ b/tests/helper.js
@@ -1,3 +1,5 @@
+'use strict';
+
 /**
  * Index helper
  */


### PR DESCRIPTION
 - allow `writeTemplate()` to return a new object to completely replace the old one
 - fix issues in documentation
 - refactor code to use more ES6 features
 - add `'use strict'` to all files to support all node versions >=4
 - upgrade dependencies
 - change package version to 0.7.0